### PR TITLE
feat: async authorization

### DIFF
--- a/src/__tests__/use-fetch.test.ts
+++ b/src/__tests__/use-fetch.test.ts
@@ -289,4 +289,48 @@ describe('baseUseFetch', () => {
       success: true,
     });
   });
+
+  it('allows promise-bsaed getAuthorization', async () => {
+    fetchMock.postOnce(`${url}/api2`, {
+      status: 201,
+      body: JSON.stringify({ success: true }),
+    });
+
+    const useFetch = baseUseFetch({
+      getAuthorization: async () => ({ Authorization: 'Token hi' }),
+      getBaseUrl: () => 'http://example.com',
+      defaultOptions: {
+        method: 'POST',
+      },
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFetch({
+        url: '/api2',
+        options: {},
+        onSuccess: () => {},
+        onError: () => {},
+      }),
+    );
+
+    let [state, callback] = result.current;
+
+    expect(state.loading).toBe(false);
+
+    act(() => callback());
+
+    [state, callback] = result.current;
+
+    expect(state.loading).toBe(true);
+
+    await waitForNextUpdate();
+
+    [state, callback] = result.current;
+
+    expect(state.loading).toBe(false);
+
+    expect(state.value).toStrictEqual({
+      success: true,
+    });
+  });
 });

--- a/src/use-fetch.ts
+++ b/src/use-fetch.ts
@@ -121,7 +121,9 @@ export const useFetch = <S = any>({
 };
 
 export type BaseUseFetch = {
-  getAuthorization?: () => { Authorization: string };
+  getAuthorization?: () =>
+    | { Authorization: string }
+    | Promise<{ Authorization: string }>;
   getBaseUrl?: () => string;
   defaultOptions?: Partial<RequestInit>;
 };
@@ -142,12 +144,19 @@ export const baseUseFetch = ({
       : options;
 
     if (getAuthorization) {
+      const headers = {
+        ...(fetchOptions.headers || {}),
+      };
+
+      Object.defineProperty(headers, 'Authorization', {
+        get: async function() {
+          return await getAuthorization();
+        },
+      });
+
       fetchOptions = {
         ...fetchOptions,
-        headers: {
-          ...(fetchOptions.headers || {}),
-          ...getAuthorization(),
-        },
+        headers,
       };
     }
 


### PR DESCRIPTION
Adds the ability to provide a promise-like function to `getAuthorization` in `baseUseFetch`. Enabling people using react-native's `AsyncStorage`